### PR TITLE
Fix "Trying to get property 'post_type' of non-object"

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -6,8 +6,6 @@ namespace App;
  * Add <body> classes
  */
 add_filter('body_class', function (array $classes) {
-    global $post;
-
     /** Add page slug if it doesn't exist */
     if (is_single() || is_page() && !is_front_page()) {
         if (!in_array(basename(get_permalink()), $classes)) {
@@ -21,7 +19,7 @@ add_filter('body_class', function (array $classes) {
     }
 
     /** Add child class to sessions */
-    if ($post->post_type === 'pcc-event' && $post->post_parent) {
+    if (is_singular('pcc-event') && get_post()->post_parent) {
         $classes[] = 'pcc-event-session';
     }
 


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

In the `body_class` filter, we were sometimes attempting to access the `$post` object when it did not exist. This PR more narrowly focuses the logic which addes the event session class to the body.

## Steps to test

1. Visit an event session.
2. Visit the home page.

**Expected behavior:** The body of an event session should have the `pcc-event-session` class, and no errors should be logged when visiting the home page.

## Additional information

Not applicable.

## Related issues

Not applicable.