### PR TITLE
Fix breadcrumb bug for events

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -168,7 +168,7 @@ USA';
             $home = get_post(get_option('page_for_posts'));
             $url = get_permalink($home->post_parent);
             $label = sprintf(__('Back to %s', 'pcc'), get_the_title($home->post_parent));
-        } elseif (is_single() || is_archive()) {
+        } elseif (is_singular('post') || is_archive()) {
             $url = get_permalink(get_option('page_for_posts'));
             $label = __('Back to blog', 'pcc');
         } else {


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes an issue where the breadcrumb on a single event would read "Back to blog".

## Steps to test

1. Visit an event.

**Expected behavior:** Breadcrumb directs user back to home.

## Additional information

Not applicable.

## Related issues

Not applicable.
