### PR TITLE
Fix spacing on People profiles

### DIFF
--- a/resources/assets/styles/layouts/_people.css
+++ b/resources/assets/styles/layouts/_people.css
@@ -6,7 +6,7 @@
   background: var(--white);
 }
 
-.single-pcc-person main .content {
+.single-pcc-person main .entry-content {
   background-color: var(--off-white);
   padding-bottom: var(--spacing-140);
   padding-top: var(--spacing-102);


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes insufficient space below profile images on People pages.

## Steps to test

1. Visit a profile.

**Expected behavior:** Spacing should match what's seen here: https://platform.coop/about/vision-and-advantages/

## Additional information

Not applicable.

## Related issues

Not applicable.
