### PR TITLE
Add new fields to people pages (fixes #120)

### DIFF
--- a/app/Controllers/SinglePccPerson.php
+++ b/app/Controllers/SinglePccPerson.php
@@ -25,6 +25,7 @@ class SinglePccPerson extends Controller
         $data['title'] = get_post_meta($post->ID, 'pcc_person_title', true);
         $data['organization'] = get_post_meta($post->ID, 'pcc_person_organization', true);
         $data['organization_link'] = get_post_meta($post->ID, 'pcc_person_organization_link', true);
+        $data['twitter_username'] = get_post_meta($post->ID, 'pcc_person_twitter_username', true);
         return $data;
     }
 }

--- a/resources/views/partials/person-header.blade.php
+++ b/resources/views/partials/person-header.blade.php
@@ -11,9 +11,16 @@
       @endif
       <h1>{!! App::title() !!}</h1>
       @if($participant_data['title'] && $participant_data['organization'] && $participant_data['organization_link'])
-      <p class="title">{{ $participant_data['title'] }},<br />
-        <a href="{{ $participant_data['organization_link'] }}">{{ $participant_data['organization'] }}</a>
+      <p class="title">{{ $participant_data['title'] }}, <a href="{{ $participant_data['organization_link'] }}">{{ $participant_data['organization'] }}</a>
       </p>
+      @elseif($participant_data['title'] && $participant_data['organization'])
+      <p class="title">{{ $participant_data['title'] }}, {{ $participant_data['organization'] }}
+      </p>
+      @elseif($participant_data['title'])
+      <p class="title">{{ $participant_data['title'] }}</p>
+      @endif
+      @if($participant_data['twitter_username'])
+      <p class="twitter"><a href="https://twitter.com/{{ str_replace('@', '', $participant_data['twitter_username']) }}">{{ $participant_data['twitter_username'] }}</a></p>
       @endif
     </div>
     @if(has_post_thumbnail())


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds title and organization field support when organization links aren't present, adds Twitter field.

## Steps to test

1. Visit a profile.

**Expected behavior:** Fields are visible.

## Additional information

Not applicable.

## Related issues

- Fixes #120
