### PR TITLE
Randomize participants (fix #125)

### DIFF
--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -28,7 +28,7 @@ class SinglePccEvent extends Controller
                 ];
             }
         }
-        ksort($output);
+        shuffle($output);
         if ($limit !== -1 && $limit >= 1) {
             return array_slice($output, 0, $limit);
         }


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Randomizes the participant order as per #125.

## Steps to test

1. Visit conference participants.

**Expected behavior:** Order is random.

## Additional information

Not applicable.

## Related issues

- Resolves #125
