### PR TITLE
Add short/full titles to People cards/pages

### DIFF
--- a/app/Controllers/SinglePccPerson.php
+++ b/app/Controllers/SinglePccPerson.php
@@ -23,6 +23,7 @@ class SinglePccPerson extends Controller
         global $post;
         $data = [];
         $data['title'] = get_post_meta($post->ID, 'pcc_person_title', true);
+        $data['short_title'] = get_post_meta($post->ID, 'pcc_person_short_title', true);
         $data['organization'] = get_post_meta($post->ID, 'pcc_person_organization', true);
         $data['links'] = get_post_meta($post->ID, 'pcc_person_links', true);
         if (is_array($data['links'])) {

--- a/resources/views/partials/event-participant.blade.php
+++ b/resources/views/partials/event-participant.blade.php
@@ -11,10 +11,9 @@
   <div class="participant__details text">
     <p class="participant__name title">
       <a href="{{ get_permalink() }}participants/{{ $participant['slug'] }}/">{!! $participant['name'] !!} @svg('chevron-right', ['aria-hidden' => 'true', 'viewbox' => '0 0 5.93335 9.85001'])</a>
-      @if($participant['title'])
+      @if(isset($participant['short_title']))
       <span class="participant__title">
-        {{ $participant['title'] }}@if($participant['organization']), {{ $participant['organization'] }}
-        @endif
+        {{ $participant['short_title'] }}
       </span>
       @endif
     </p>

--- a/resources/views/partials/person-header.blade.php
+++ b/resources/views/partials/person-header.blade.php
@@ -10,10 +10,8 @@
         @include('partials/breadcrumb')
       @endif
       <h1>{!! App::title() !!}</h1>
-      @if($participant_data['title'] && $participant_data['organization'])
-      <p class="title">{{ $participant_data['title'] }}, {{ $participant_data['organization'] }}</p>
-      @elseif($participant_data['title'])
-      <p class="title">{{ $participant_data['title'] }}</p>
+      @if(isset($participant_data['title']))
+        {!! wpautop($participant_data['title']) !!}
       @endif
     </div>
     @if(has_post_thumbnail())


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds support for a new short title field for People which will be used on their card in grid views.

## Steps to test

1. Add a short title to a Person.
2. View their card in a grid view.

**Expected behavior:** The short title should be used in place of the full title.

## Additional information

Not applicable.

## Related issues

- https://github.com/platform-coop-toolkit/pcc-framework/pull/70
