### PR TITLE
Display person locality if set

### DIFF
--- a/app/Controllers/SinglePccPerson.php
+++ b/app/Controllers/SinglePccPerson.php
@@ -25,6 +25,13 @@ class SinglePccPerson extends Controller
         $data['title'] = get_post_meta($post->ID, 'pcc_person_title', true);
         $data['short_title'] = get_post_meta($post->ID, 'pcc_person_short_title', true);
         $data['organization'] = get_post_meta($post->ID, 'pcc_person_organization', true);
+        $locality = get_post_meta($post->ID, 'pcc_person_locality', true);
+        $country = get_post_meta($post->ID, 'pcc_person_country', true);
+        if ($locality && $country) {
+            $data['locality'] = implode(', ', [$locality, $country]);
+        } elseif ($country) {
+            $data['locality'] = $country;
+        }
         $data['links'] = get_post_meta($post->ID, 'pcc_person_links', true);
         if (is_array($data['links'])) {
             foreach ($data['links'] as $key => $value) {

--- a/resources/assets/styles/layouts/_people.css
+++ b/resources/assets/styles/layouts/_people.css
@@ -1,5 +1,10 @@
-.single-pcc-person h1 + .title {
+.single-pcc-person h1 + p {
   margin-top: var(--spacing-30);
+}
+
+.single-pcc-person .locality {
+  font-style: italic;
+  margin-top: 0;
 }
 
 .single-pcc-person main {

--- a/resources/views/partials/person-header.blade.php
+++ b/resources/views/partials/person-header.blade.php
@@ -13,6 +13,9 @@
       @if(isset($participant_data['title']))
         {!! wpautop($participant_data['title']) !!}
       @endif
+      @if(isset($participant_data['locality']))
+        <p class="locality">{{ $participant_data['locality'] }}</p>
+      @endif
     </div>
     @if(has_post_thumbnail())
       <div class="fold">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds locality to a person's page (see https://github.com/platform-coop-toolkit/pcc-framework/pull/71).

## Steps to test

1. Add city/country to a Person.
2. View their page.

**Expected behavior:** Displays.

## Additional information

Not applicable.

## Related issues

- https://github.com/platform-coop-toolkit/pcc-framework/pull/71
