### PR TITLE
Hide people from People page unless explicitly shown

### DIFF
--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -11,7 +11,7 @@ use Sober\Controller\Controller;
 
 class SinglePccEvent extends Controller
 {
-    public static function eventParticipants($limit = -1)
+    public static function eventParticipants($limit = -1, $random = false)
     {
         global $id;
         $output = [];
@@ -27,7 +27,11 @@ class SinglePccEvent extends Controller
                 ];
             }
         }
-        shuffle($output);
+        if ($random) {
+            shuffle($output);
+        } else {
+            ksort($output);
+        }
         if ($limit !== -1 && $limit >= 1) {
             return array_slice($output, 0, $limit);
         }

--- a/app/filters.php
+++ b/app/filters.php
@@ -184,6 +184,13 @@ add_filter('query_vars', function ($vars) {
 
 // TODO: Add rel="canonical" for participants pointing back to people page.
 
+add_filter('pre_get_posts', function ($query) {
+    if (!is_admin() && is_post_type_archive('pcc-person') && !empty($query->query['post_type']  == 'pcc-person')) {
+        $query->set('meta_key', 'pcc_person_show_on_people');
+        $query->set('meta_value', 'on');
+    }
+});
+
 add_filter('wp_get_attachment_image_attributes', function ($attr, $attachment, $size) {
     if (is_array($size)) {
         $attr['sizes'] = $size[0] . 'px';

--- a/resources/views/partials/content-single-pcc-event.blade.php
+++ b/resources/views/partials/content-single-pcc-event.blade.php
@@ -7,7 +7,7 @@
     </div>
     <div class="wp-block-column">
       <ul class="participants cards cards--two-columns">
-      @foreach(SinglePccEvent::eventParticipants(6) as $participant)
+      @foreach(SinglePccEvent::eventParticipants(6, true) as $participant)
         @include('partials/event-participant')
       @endforeach
       </ul>


### PR DESCRIPTION
Randomize participants on front page of conference pages

* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR follows up on https://github.com/platform-coop-toolkit/pcc/pull/128 and https://github.com/platform-coop-toolkit/pcc-framework/pull/69, making two changes:

- Participants are now randomize on the front page of the conference but not the full participants list.
- People who are not set to show on the People page are hidden by default.

## Steps to test

1. Visit `/people`.
2. Visit conference participants page.

**Expected behavior:** 1) Nothing there yet. 2) Alphabetized.

## Additional information

Not applicable.

## Related issues

- https://github.com/platform-coop-toolkit/pcc/pull/128
- https://github.com/platform-coop-toolkit/pcc-framework/pull/69
