### PR TITLE
Add user configurable sorting to event participants

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -41,7 +41,7 @@ class App extends Controller
         }
         if ($post->post_type === 'pcc-event') {
             if (isset($wp->query_vars['participants'])) {
-                if ($wp->query_vars['participants'] === 'yes') {
+                if (in_array($wp->query_vars['participants'], ['alphabetical', 'random'], true)) {
                     return __('Participants', 'pcc');
                 }
                 $person = get_page_by_path(

--- a/app/setup.php
+++ b/app/setup.php
@@ -219,7 +219,12 @@ add_action('after_setup_theme', function () {
 add_action('init', function () {
     add_rewrite_rule(
         '^events/([^/]+)/participants/?$',
-        'index.php?pcc-event=$matches[1]&participants=yes',
+        'index.php?pcc-event=$matches[1]&participants=random',
+        'top'
+    );
+    add_rewrite_rule(
+        '^events/([^/]+)/participants/alphabetical/?$',
+        'index.php?pcc-event=$matches[1]&participants=alphabetical',
         'top'
     );
     add_rewrite_rule(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3539,6 +3539,11 @@
         "es-abstract": "^1.7.0"
       }
     },
+    "array-parallel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -14960,6 +14965,11 @@
       "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
       "dev": true
     },
+    "matches-selector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -20702,6 +20712,17 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "shufflejs": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/shufflejs/-/shufflejs-5.2.3.tgz",
+      "integrity": "sha512-x/vb3Kdyb5X4GykbdOS49EU34jtMag2aYODL/z0nWT0DVFpWNk08xVeonKSMZnH4/piSWLjCkn4296BlxhvDnw==",
+      "requires": {
+        "array-parallel": "^0.1.3",
+        "matches-selector": "^1.0.0",
+        "throttleit": "^1.0.0",
+        "tiny-emitter": "^2.1.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -22756,6 +22777,11 @@
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -22799,6 +22825,11 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-lr": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "custom-event-polyfill": "^1.0.7"
+    "custom-event-polyfill": "^1.0.7",
+    "shufflejs": "^5.2.3"
   },
   "devDependencies": {
     "@percy/script": "~1.0",

--- a/resources/views/partials/content-single-pcc-event-participants.blade.php
+++ b/resources/views/partials/content-single-pcc-event-participants.blade.php
@@ -1,4 +1,10 @@
 <div class="entry-content" id="content">
+  <div class="wp-block-group">
+    <p><em>{{ sprintf(__('Participants are shown in %s order.', 'pcc'), $participant_order) }}</em></p>
+    <p class="wp-block-button is-style-secondary">
+      <a class="wp-block-button__link" href="{{ $reorder_participants['link'] }}">{{ $reorder_participants['label'] }}</a>
+    </p>
+  </div>
   @if(!empty(SinglePccEvent::eventParticipants()))
   <div class="wp-block-group">
     <ul class="participants cards cards--three-columns">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Allows user to choose alphabetical or random views for event participants page and clearly communicates to users which view they are on.

## Steps to test

Not applicable.

## Additional information

Not applicable.

## Related issues

- Reverts #135.
- Resolves #125.
