### PR TITLE
Fix bugs with session display

### DIFF
--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -63,7 +63,7 @@ class SinglePccEvent extends Controller
         $venue_name = get_post_meta($id, 'pcc_event_venue', true);
         $venue_street_address = get_post_meta($id, 'pcc_event_venue_street_address', true);
         if ($venue_name && $venue_street_address) {
-            return implode(', ', $venue_name, $venue_street_address);
+            return implode('<br />', [$venue_name, $venue_street_address]);
         } elseif ($venue_name) {
             return $venue_name;
         }

--- a/resources/views/partials/event-meta.blade.php
+++ b/resources/views/partials/event-meta.blade.php
@@ -2,7 +2,7 @@
   <p class="datetime">@svg('calendar', ['aria-hidden' => 'true']) <time>{{ $event_date }}</time></p>
   @if($event_venue)
     @if($post->post_parent)
-    <p class="address">@svg('location', ['aria-hidden' => 'true']) {{ SinglePccEvent::sessionVenue($post->ID) }}</p>
+    <p class="address">@svg('location', ['aria-hidden' => 'true']) {!! SinglePccEvent::sessionVenue($post->ID) !!}</p>
     @else
     <p class="address" translate="no">@svg('location', ['aria-hidden' => 'true']) {!! str_replace('<p translate="no" class="address">', '', $event_venue) !!}
     @endif

--- a/resources/views/partials/event-participant.blade.php
+++ b/resources/views/partials/event-participant.blade.php
@@ -10,7 +10,7 @@
   </figure>
   <div class="participant__details text">
     <p class="participant__name title">
-      <a href="{{ get_permalink() }}participants/{{ $participant['slug'] }}/">{!! $participant['name'] !!} @svg('chevron-right', ['aria-hidden' => 'true', 'viewbox' => '0 0 5.93335 9.85001'])</a>
+      <a href="{{ ($post->post_parent) ? get_permalink($post->post_parent) : get_permalink() }}participants/{{ $participant['slug'] }}/">{!! $participant['name'] !!} @svg('chevron-right', ['aria-hidden' => 'true', 'viewbox' => '0 0 5.93335 9.85001'])</a>
       @if($participant['short_title'])
       <span class="participant__title">
         {{ $participant['short_title'] }}


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes issues identified by @difea451 in #147 and #148.

## Steps to test

1. Visit http://platform.coop/events/conference-2019/this-is-zambia-by-pilato/

**Expected behavior:** Event session address is displayed properly. Event session participants link to the correct place.

## Additional information

Not applicable.

## Related issues

- Resolves #147
- Resolves #148
