### PR TITLE
Fix issue with long names (resolves #146)

### DIFF
--- a/resources/assets/styles/layouts/_people.css
+++ b/resources/assets/styles/layouts/_people.css
@@ -1,3 +1,8 @@
+.single-pcc-person h1 {
+  background-color: var(--white);
+  padding-right: 1rem;
+}
+
 .single-pcc-person h1 + p {
   margin-top: var(--spacing-30);
 }
@@ -54,4 +59,10 @@
 
 .single-pcc-person main .links + * {
   margin-top: var(--spacing-60);
+}
+
+@media (--breakpoint-lg) {
+  .single-pcc-person .page-header__content p {
+    max-width: calc(22.91666666666 * 1rem);
+  }
 }


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds a white background to names which overflow the header content box on Person pages.

## Steps to test

1. Visit the profile with an issue identified in #146.

**Expected behavior:** Name has a backdrop to enhance readability.

## Additional information

Not applicable.

## Related issues

- Resolves #146.