### PR TITLE
Ensure that simultaneous sessions show on program

### DIFF
--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -310,14 +310,18 @@ class SinglePccEvent extends Controller
         if ($program->have_posts()) {
             while ($program->have_posts()) {
                 $program->the_post();
-                $tmp[ $program->post->pcc_event_start ] = $program->post;
+                if (! isset($tmp[ $program->post->pcc_event_start ])) {
+                    $tmp[ $program->post->pcc_event_start ] = $program->post;
+                } else {
+                    $tmp[ absint($program->post->pcc_event_start) + 1 ] = $program->post;
+                }
             }
             wp_reset_postdata();
         }
         ksort($tmp);
         $previous_day = false;
         foreach ($tmp as $k => $v) {
-            $day = strftime('%B %e, %Y', $v->pcc_event_start);
+            $day = strftime('%A, %B %e, %Y', $v->pcc_event_start);
             if ($previous_day && $previous_day === $day) {
                 $result[ $previous_day ][ $v->post_name ] = $v;
             } else {

--- a/resources/views/partials/content-single-pcc-event-program.blade.php
+++ b/resources/views/partials/content-single-pcc-event-program.blade.php
@@ -4,7 +4,7 @@
     @foreach($event_program as $date => $day)
     <div class="program wp-block-columns has-2-columns" id="day-{{ $loop->iteration }}">
       <div class="wp-block-column">
-        <h2>{{ sprintf(__('Day %d', 'pcc'), $loop->iteration) }}<br />{{ $date }}</h2>
+        <h2>{{ sprintf(__('Day %d', 'pcc'), $loop->iteration) }}: {{ $date }}</h2>
       </div>
       <div class="wp-block-column">
           <ul class="program__day">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds day of week to day headings on program page. Ensures that multiple sessions beginning at the same time show up as expected.

## Steps to test

1. Visit program.

**Expected behavior:** Observe above changes.

## Additional information

Not applicable.

## Related issues

- Fixes #153.
- Fixes #154.
