### PR TITLE
Only show credited photos on photo credits page

### DIFF
--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -11,70 +11,80 @@ class Page extends Controller
         if (basename(get_page_template()) !== 'page-photo-credits.blade.php') {
             return;
         }
-        $photos = get_posts(['post_type' => 'attachment', 'numberposts' => '-1']);
+        $photos = get_posts([
+            'post_type' => 'attachment',
+            'numberposts' => '-1',
+            'order' => 'asc',
+            'meta_query' => [
+                'relation' => 'OR',
+                [
+                    'key'     => 'pcc_attachment_creator_name',
+                    'compare' => 'EXISTS',
+                ],
+                [
+                    'key'     => 'pcc_attachment_organization_name',
+                    'compare' => 'EXISTS',
+                ],
+            ],
+        ]);
         foreach ($photos as $k => $photo) {
-            if (get_post_type($photo->post_parent) === 'pcc-event') {
-                // Don't include event banners.
-                unset($photos[$k]);
-            } else {
-                $pcc_attachment_creator_name = get_post_meta($photo->ID, 'pcc_attachment_creator_name', true);
-                $pcc_attachment_creator_link = get_post_meta($photo->ID, 'pcc_attachment_creator_link', true);
-                $pcc_attachment_organization_name = get_post_meta($photo->ID, 'pcc_attachment_organization_name', true);
-                $pcc_attachment_organization_link = get_post_meta($photo->ID, 'pcc_attachment_organization_link', true);
-                if ($pcc_attachment_creator_name &&
-                    $pcc_attachment_organization_name) {
-                    if ($pcc_attachment_creator_link) {
-                        $creator = sprintf(
-                            '<a href="%1$s">%2$s</a>',
-                            $pcc_attachment_creator_link,
-                            $pcc_attachment_creator_name
-                        );
-                    } else {
-                        $creator = $pcc_attachment_creator_name;
-                    }
-                    if ($pcc_attachment_organization_link) {
-                        $organization = sprintf(
-                            '<a href="%1$s">%2$s</a>',
-                            $pcc_attachment_organization_link,
-                            $pcc_attachment_organization_name
-                        );
-                    } else {
-                        $organization = $pcc_attachment_organization_name;
-                    }
-                    $photo->credit = sprintf(
-                        'Photo by %1$s for %2$s',
-                        $creator,
-                        $organization
+            $pcc_attachment_creator_name = get_post_meta($photo->ID, 'pcc_attachment_creator_name', true);
+            $pcc_attachment_creator_link = get_post_meta($photo->ID, 'pcc_attachment_creator_link', true);
+            $pcc_attachment_organization_name = get_post_meta($photo->ID, 'pcc_attachment_organization_name', true);
+            $pcc_attachment_organization_link = get_post_meta($photo->ID, 'pcc_attachment_organization_link', true);
+            if ($pcc_attachment_creator_name &&
+                $pcc_attachment_organization_name) {
+                if ($pcc_attachment_creator_link) {
+                    $creator = sprintf(
+                        '<a href="%1$s">%2$s</a>',
+                        $pcc_attachment_creator_link,
+                        $pcc_attachment_creator_name
                     );
-                } elseif ($pcc_attachment_creator_name) {
-                    if ($pcc_attachment_creator_link) {
-                        $creator = sprintf(
-                            '<a href="%1$s">%2$s</a>',
-                            $pcc_attachment_creator_link,
-                            $pcc_attachment_creator_name
-                        );
-                    } else {
-                        $creator = $pcc_attachment_creator_name;
-                    }
-                    $photo->credit = sprintf(
-                        'Photo by %1$s',
-                        $creator
-                    );
-                } elseif ($pcc_attachment_organization_name) {
-                    if ($pcc_attachment_organization_link) {
-                        $organization = sprintf(
-                            '<a href="%1$s">%2$s</a>',
-                            $pcc_attachment_organization_link,
-                            $pcc_attachment_organization_name
-                        );
-                    } else {
-                        $organization = $pcc_attachment_organization_name;
-                    }
-                    $photo->credit = sprintf(
-                        'Photo by %1$s',
-                        $organization
-                    );
+                } else {
+                    $creator = $pcc_attachment_creator_name;
                 }
+                if ($pcc_attachment_organization_link) {
+                    $organization = sprintf(
+                        '<a href="%1$s">%2$s</a>',
+                        $pcc_attachment_organization_link,
+                        $pcc_attachment_organization_name
+                    );
+                } else {
+                    $organization = $pcc_attachment_organization_name;
+                }
+                $photo->credit = sprintf(
+                    'Photo by %1$s for %2$s',
+                    $creator,
+                    $organization
+                );
+            } elseif ($pcc_attachment_creator_name) {
+                if ($pcc_attachment_creator_link) {
+                    $creator = sprintf(
+                        '<a href="%1$s">%2$s</a>',
+                        $pcc_attachment_creator_link,
+                        $pcc_attachment_creator_name
+                    );
+                } else {
+                    $creator = $pcc_attachment_creator_name;
+                }
+                $photo->credit = sprintf(
+                    'Photo by %1$s',
+                    $creator
+                );
+            } elseif ($pcc_attachment_organization_name) {
+                if ($pcc_attachment_organization_link) {
+                    $organization = sprintf(
+                        '<a href="%1$s">%2$s</a>',
+                        $pcc_attachment_organization_link,
+                        $pcc_attachment_organization_name
+                    );
+                } else {
+                    $organization = $pcc_attachment_organization_name;
+                }
+                $photo->credit = sprintf(
+                    'Photo by %1$s',
+                    $organization
+                );
             }
         }
         return $photos;


### PR DESCRIPTION

* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR changes the photo credits page so that only credited photos are shown.

## Steps to test

1. Navigate to photo credits page.

**Expected behavior:** Only photos with credits appear.

## Additional information

Not applicable.

## Related issues

- Fixes #166.
