### PR TITLE
Support line breaks in venue name (fix #169)

### DIFF
--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -63,9 +63,9 @@ class SinglePccEvent extends Controller
         $venue_name = get_post_meta($id, 'pcc_event_venue', true);
         $venue_street_address = get_post_meta($id, 'pcc_event_venue_street_address', true);
         if ($venue_name && $venue_street_address) {
-            return implode('<br />', [$venue_name, $venue_street_address]);
+            return implode('<br />', [nl2br($venue_name), $venue_street_address]);
         } elseif ($venue_name) {
-            return $venue_name;
+            return nl2br($venue_name);
         }
         return false;
     }
@@ -229,7 +229,7 @@ class SinglePccEvent extends Controller
         };
         $address = new Address();
         $address = $address
-            ->withOrganization($venue_name)
+            ->withOrganization(nl2br($venue_name))
             ->withAddressLine1($venue_street_address)
             ->withLocality($venue_locality)
             ->withAdministrativeArea($venue_region)


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes #169. Relies on https://github.com/platform-coop-toolkit/pcc-framework/pull/86.

## Steps to test

1. Add a line break to a venue name.
2. View the event.

**Expected behavior:** Line break is presented.

## Additional information

Not applicable.

## Related issues

- Fixes #169.