### PR TITLE
fix: improve breadcrumb layout (fixes #55)

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -157,10 +157,15 @@ USA';
         $label = __('Home', 'pcc');
         $hide_back_to = true;
 
-        if (isset($wp->query_vars['participants']) || isset($wp->query_vars['program']) || isset($wp->query_vars['event'])) {
+        if (isset($wp->query_vars['participants']) ||
+            isset($wp->query_vars['program']) ||
+            isset($wp->query_vars['event'])) {
             // We are on a sub-view of a top-level, so the breadcrumb should link to the event itself.
-            $url = (isset($wp->query_vars['event'])) ? home_url("/events/{$wp->query_vars['event']}/") : get_the_permalink($post);
+            $url = (isset($wp->query_vars['event'])) ?
+                home_url("/events/{$wp->query_vars['event']}/") :
+                get_the_permalink($post);
             $label = __('Event', 'pcc');
+            $hide_back_to = false;
         } elseif ($post->post_parent) {
             // We have a parent to link back to.
             $url = get_the_permalink($post->post_parent);
@@ -172,7 +177,6 @@ USA';
             $home = get_post(get_option('page_for_posts'));
             $url = get_permalink($home->post_parent);
             $label = get_the_title($home->post_parent);
-            $hide_back_to = true;
         } elseif (is_post_type_archive('pcc-person')) {
             // Back home.
             $url = get_home_url();

--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -153,43 +153,42 @@ USA';
     {
         global $post, $wp;
 
-        if (isset($wp->query_vars['participants']) || isset($wp->query_vars['program'])) {
+        $url = get_home_url();
+        $label = __('Home', 'pcc');
+        $hide_back_to = true;
+
+        if (isset($wp->query_vars['participants']) || isset($wp->query_vars['program']) || isset($wp->query_vars['event'])) {
             // We are on a sub-view of a top-level, so the breadcrumb should link to the event itself.
-            $url = get_the_permalink($post);
-            $label = __('Back to event', 'pcc');
-        } elseif (isset($wp->query_vars['event'])) {
-            // Participant in event view.
-            $url = home_url("/events/{$wp->query_vars['event']}/");
-            $label = __('Back to event', 'pcc');
+            $url = (isset($wp->query_vars['event'])) ? home_url("/events/{$wp->query_vars['event']}/") : get_the_permalink($post);
+            $label = __('Event', 'pcc');
         } elseif ($post->post_parent) {
             // We have a parent to link back to.
             $url = get_the_permalink($post->post_parent);
             $label = ($post->post_type === 'pcc-event') ?
-                __('Back to event', 'pcc') :
-                sprintf(__('Back to %s', 'pcc'), get_the_title($post->post_parent));
+                __('Event', 'pcc') :
+                get_the_title($post->post_parent);
+            $hide_back_to = ($post->post_type === 'pcc-event') ? false : true;
         } elseif (is_home()) {
             $home = get_post(get_option('page_for_posts'));
             $url = get_permalink($home->post_parent);
-            $label = sprintf(__('Back to %s', 'pcc'), get_the_title($home->post_parent));
+            $label = get_the_title($home->post_parent);
+            $hide_back_to = true;
         } elseif (is_post_type_archive('pcc-person')) {
             // Back home.
             $url = get_home_url();
-            $label = __('Back to home', 'pcc');
+            $label = __('Home', 'pcc');
         } elseif (is_singular('post') || is_archive()) {
             $url = get_permalink(get_option('page_for_posts'));
-            $label = __('Back to blog', 'pcc');
+            $label = __('Blog', 'pcc');
         } elseif (is_singular('pcc-person') || is_archive()) {
             $url = get_permalink(get_page_by_title('People')->ID);
-            $label = __('Back to People', 'pcc');
-        } else {
-            // Back home.
-            $url = get_home_url();
-            $label = __('Back to home', 'pcc');
+            $label = __('People', 'pcc');
         }
 
         return [
             'url' => $url,
             'label' => $label,
+            'hide_back_to' => $hide_back_to,
         ];
     }
 }

--- a/resources/views/partials/breadcrumb.blade.php
+++ b/resources/views/partials/breadcrumb.blade.php
@@ -1,3 +1,8 @@
 <p class="breadcrumb">
-  <a href="{{ $breadcrumb['url'] }}">{{ $breadcrumb['label'] }}</a>
+  <a href="{{ $breadcrumb['url'] }}">
+    @if($breadcrumb['hide_back_to'])
+      <span class="screen-reader-text">{{ __('Back to', 'pcc') }} </span>{!! $breadcrumb['label'] !!}
+    @else
+    {!! sprintf(__('Back to %s', 'pcc'), $breadcrumb['label']) !!}
+    @endif</a>
 </p>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves #55. Breadcrumbs now use the parent title with "Back to" visually hidden, but accessible to screen readers.

## Steps to test

1. Visit an event and sub pages, nested pages, and blog posts.

**Expected behavior:** Ensure that the breadcrumbs display as expected throughout, especially on mobile.

## Additional information

Not applicable.

## Related issues

- Resolves #55.
