### PR TITLE
10517 project post type

### DIFF
--- a/resources/assets/styles/layouts/_pages.css
+++ b/resources/assets/styles/layouts/_pages.css
@@ -4,3 +4,4 @@
 @import "pages/_contact-us.css";
 @import "pages/_persona.css";
 @import "pages/_photo-credits.css";
+@import "pages/_project.css";

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -1,10 +1,17 @@
-.page-project .main {
-  padding: var(--gutter);
+.page-project .project-header-media {
+  margin: 0;
+  padding: 0;
 }
 
-.page-project .page-header {
-  padding: 0;
-  margin: 0;
+.page-project .project-header-media img {
+  max-height: 20em;
+  overflow: hidden;
+  object-fit: cover;
+  width: 100%;
+}
+
+.page-project .project-content {
+  padding: var(--gutter);
 }
 
 .page-project .section {

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -12,7 +12,7 @@
   left: var(--project-spacing);
   margin: 0;
   position: absolute;
-  top: 21rem;
+  top: 20rem;
 }
 
 .page-project .project-header-media img {

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -1,0 +1,36 @@
+.page-project .main {
+  padding: var(--gutter);
+}
+
+.page-project .page-header {
+  padding: 0;
+  margin: 0;
+}
+
+.page-project .section {
+  border-top: 2px solid var(--light-green);
+  margin-top: var(--gutter);
+  padding-top: var(--gutter);
+  padding-bottom: var(--gutter);
+  /* margin-left: auto;
+  margin-right: auto;
+  max-width: 100%;
+  padding-left: var(--gutter);
+  padding-right: var(--gutter);
+  width: 100%; */
+}
+
+/* .page-project .section-heading {
+  color: var(--dark-green);
+  font-weight: bold;
+} */
+
+.page-project .about-project {
+  background: var(--light-grey);
+  border: none;
+  padding: var(--gutter);
+}
+
+.page-project .about-project .section-heading {
+
+}

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -36,11 +36,6 @@
   padding: var(--project-spacing) 0;
 }
 
-/* .page-project .section-heading {
-  color: var(--dark-green);
-  font-weight: bold;
-} */
-
 .page-project .about-project {
   background: var(--light-grey);
   border: none;
@@ -48,6 +43,20 @@
   margin: 3rem 0 5rem;
 }
 
-.page-project .about-project .section-heading {
+.page-project .heading-with-line {
+  align-items: center;
+  display: flex;
+}
 
+.page-project .heading-with-line .section-heading {
+  margin: 0 1rem 0 0;
+}
+
+.page-project .heading-with-line hr {
+  border-width: 1px;
+  color: var(--dark-green);
+  flex-grow: 2;
+  height: 1px;
+  margin-left: 0;
+  margin-right: 0;
 }

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -3,6 +3,14 @@
   padding: 0;
 }
 
+.page-project .project-header h1 {
+  color: var(--white);
+  left: var(--gutter);
+  margin: 0;
+  position: absolute;
+  top: 21rem;
+}
+
 .page-project .project-header-media img {
   max-height: 20em;
   overflow: hidden;

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -31,15 +31,15 @@
 }
 
 .page-project .section {
-  border-top: 2px solid var(--light-green);
+  border-top: 2px solid var(--green);
   margin: 1rem;
   padding: var(--project-spacing) 0;
 }
 
 .page-project .about-project {
-  background: var(--light-grey);
+  background: var(--off-white);
   border: none;
-  padding: var(--project-spacing);
+  padding: 2.5rem;
   margin: 3rem 0 5rem;
 }
 

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -23,20 +23,17 @@
 }
 
 .page-project .project-content {
-  padding: var(--project-spacing);
+  margin: 0 2rem;
+}
+
+.page-project .project-breadcrumbs {
+  margin: 1rem;
 }
 
 .page-project .section {
   border-top: 2px solid var(--light-green);
-  margin-top: var(--project-spacing);
-  padding-top: var(--project-spacing);
-  padding-bottom: var(--project-spacing);
-  /* margin-left: auto;
-  margin-right: auto;
-  max-width: 100%;
-  padding-left: var(--project-spacing);
-  padding-right: var(--project-spacing);
-  width: 100%; */
+  margin: 1rem;
+  padding: var(--project-spacing) 0;
 }
 
 /* .page-project .section-heading {
@@ -48,6 +45,7 @@
   background: var(--light-grey);
   border: none;
   padding: var(--project-spacing);
+  margin: 3rem 0 5rem;
 }
 
 .page-project .about-project .section-heading {

--- a/resources/assets/styles/layouts/pages/_project.css
+++ b/resources/assets/styles/layouts/pages/_project.css
@@ -1,3 +1,7 @@
+.page-project {
+  --project-spacing: var(--spacing-40, 3rem);
+}
+
 .page-project .project-header-media {
   margin: 0;
   padding: 0;
@@ -5,7 +9,7 @@
 
 .page-project .project-header h1 {
   color: var(--white);
-  left: var(--gutter);
+  left: var(--project-spacing);
   margin: 0;
   position: absolute;
   top: 21rem;
@@ -19,19 +23,19 @@
 }
 
 .page-project .project-content {
-  padding: var(--gutter);
+  padding: var(--project-spacing);
 }
 
 .page-project .section {
   border-top: 2px solid var(--light-green);
-  margin-top: var(--gutter);
-  padding-top: var(--gutter);
-  padding-bottom: var(--gutter);
+  margin-top: var(--project-spacing);
+  padding-top: var(--project-spacing);
+  padding-bottom: var(--project-spacing);
   /* margin-left: auto;
   margin-right: auto;
   max-width: 100%;
-  padding-left: var(--gutter);
-  padding-right: var(--gutter);
+  padding-left: var(--project-spacing);
+  padding-right: var(--project-spacing);
   width: 100%; */
 }
 
@@ -43,7 +47,7 @@
 .page-project .about-project {
   background: var(--light-grey);
   border: none;
-  padding: var(--gutter);
+  padding: var(--project-spacing);
 }
 
 .page-project .about-project .section-heading {

--- a/resources/views/page-project.blade.php
+++ b/resources/views/page-project.blade.php
@@ -1,0 +1,11 @@
+{{--
+  Template Name: Project Page
+--}}
+
+@extends('layouts.app')
+
+@section('content')
+  @while(have_posts()) @php the_post() @endphp
+    @include('partials.page-header')
+  @endwhile
+@endsection

--- a/resources/views/page-project.blade.php
+++ b/resources/views/page-project.blade.php
@@ -6,17 +6,19 @@
 
 @section('content')
   @while(have_posts()) @php the_post() @endphp
-    <div>
-    @include('partials.page-header')
-    <section class="about-project section">
-      <h2 class="section-heading">About</h2>
-      <p>@php the_content() @endphp</p>
-    </section>
-    <section class="featured-briefs section">
-      <h2 class="section-heading">Featured Briefs</h2>
-    </section>
-    <section class="people section">
-      <h2 class="section-heading">People</h2>
-    </section>
+    @include('partials.project-header')
+    <div class="project-content">
+      @include('partials.project-breadcrumbs')
+      <section class="about-project section">
+        <h2 class="section-heading">About</h2>
+        <p>@php the_content() @endphp</p>
+      </section>
+      <section class="featured-briefs section">
+        <h2 class="section-heading">Featured Briefs</h2>
+      </section>
+      <section class="people section">
+        <h2 class="section-heading">People</h2>
+      </section>
+    </div>
   @endwhile
 @endsection

--- a/resources/views/page-project.blade.php
+++ b/resources/views/page-project.blade.php
@@ -6,6 +6,17 @@
 
 @section('content')
   @while(have_posts()) @php the_post() @endphp
+    <div>
     @include('partials.page-header')
+    <section class="about-project section">
+      <h2 class="section-heading">About</h2>
+      <p>@php the_content() @endphp</p>
+    </section>
+    <section class="featured-briefs section">
+      <h2 class="section-heading">Featured Briefs</h2>
+    </section>
+    <section class="people section">
+      <h2 class="section-heading">People</h2>
+    </section>
   @endwhile
 @endsection

--- a/resources/views/page-project.blade.php
+++ b/resources/views/page-project.blade.php
@@ -10,7 +10,10 @@
     <div class="project-content">
       @include('partials.project-breadcrumbs')
       <section class="about-project section">
-        <h2 class="section-heading">About</h2>
+        <div class="heading-with-line">
+          <h2 class="section-heading">About</h2>
+          <hr>
+        </div>
         <p>@php the_content() @endphp</p>
       </section>
       <section class="featured-briefs section">

--- a/resources/views/partials/project-breadcrumbs.blade.php
+++ b/resources/views/partials/project-breadcrumbs.blade.php
@@ -1,0 +1,3 @@
+<div class="project-breadcrumbs">
+  @include('partials/breadcrumb')
+</div>

--- a/resources/views/partials/project-header.blade.php
+++ b/resources/views/partials/project-header.blade.php
@@ -2,4 +2,5 @@
   <figure class="project-header-media">
       @thumbnail('banner')
   </figure>
+  <h1>{!! App::title() !!}</h1>
 </div>

--- a/resources/views/partials/project-header.blade.php
+++ b/resources/views/partials/project-header.blade.php
@@ -1,0 +1,5 @@
+<div class="project-header">
+  <figure class="project-header-media">
+      @thumbnail('banner')
+  </figure>
+</div>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description
* Add base page for a project. 
* Add initial styling for a project.

## Steps to test

### Update the repos to match the new code
1. Update the current branch in the theme with this branch.
1. Update the current branch in the plugin to [10517_project_post_type](https://github.com/sassafrastech/pcc-framework/tree/10517_project_post_type).
1. Run the usual command to update the code used by the site (such as `npm run build`).

## Feature specific steps
1. In the WordPress admin, go to Page > Add New.
2. Change Page Attributes > Template to "Project Page".
3. Add information about the project in the main content section and give the project a name.
4. Save the page.

## Optional
1. Add a featured image to the page.

**Expected behavior:**

1. When visiting the page, the title of the page should appear in the header and the main page content should appear in the about section.
2. You should also see two empty sections: Featured Briefs and People.
3. If there is a featured image set, the project's title will appear over the background.
4. See https://github.com/sassafrastech/pcc/pull/1#issuecomment-637720631 for an example of what a page might look like.

## Additional information

### Known bugs
When no background image is saved, the title can overlap with the main content. This will be fixed soon with an update to this branch.

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/1853878/83654140-ab865980-a58a-11ea-95fa-62e7a6314c9c.png">