### PR TITLE
feat: hide editor for pages where it isn't used

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -273,10 +273,16 @@ add_action('init', function () {
         return;
     }
     $template_file = get_post_meta($post_id, '_wp_page_template', true);
-    // TODO: Photo credits, people.
-    if ($template_file == 'views/page-stories.blade.php') {
-        remove_post_type_support('page', 'editor');
+    switch ($template_file) {
+        case 'views/page-people.blade.php':
+        case 'views/page-photo-credits.blade.php':
+        case 'views/page-stories.blade.php':
+            remove_post_type_support('page', 'editor');
+            break;
+        default:
+            break;
     }
+    // TODO: Photo credits, people.
 });
 
 add_action('edit_form_after_title', function () {
@@ -289,10 +295,26 @@ add_action('edit_form_after_title', function () {
     }
     $template_file = get_post_meta($post_id, '_wp_page_template', true);
     // TODO: Photo credits, people.
-    if ($template_file == 'views/page-stories.blade.php') {
-        echo sprintf(
-            '<div class="notice notice-warning inline"><p>%s</p></div>',
-            __('You are currently editing the page that displays Community Stories.', 'pcc')
-        );
+    switch ($template_file) {
+        case 'views/page-people.blade.php':
+            echo sprintf(
+                '<div class="notice notice-warning inline"><p>%s</p></div>',
+                __('You are currently editing the page that displays People.', 'pcc')
+            );
+            break;
+        case 'views/page-photo-credits.blade.php':
+            echo sprintf(
+                '<div class="notice notice-warning inline"><p>%s</p></div>',
+                __('You are currently editing the page that displays photo credits.', 'pcc')
+            );
+            break;
+        case 'views/page-stories.blade.php':
+            echo sprintf(
+                '<div class="notice notice-warning inline"><p>%s</p></div>',
+                __('You are currently editing the page that displays Community Stories.', 'pcc')
+            );
+            break;
+        default:
+            break;
     }
 });

--- a/app/setup.php
+++ b/app/setup.php
@@ -263,3 +263,36 @@ add_action('init', function () {
 add_action('admin_head', function () {
     echo template('partials.favicon');
 });
+
+add_action('init', function () {
+    if (isset($_GET['post'])) {
+        $post_id = $_GET['post'];
+    } elseif (isset($_POST['post_ID'])) {
+        $post_id = $_POST['post_ID'];
+    } else {
+        return;
+    }
+    $template_file = get_post_meta($post_id, '_wp_page_template', true);
+    // TODO: Photo credits, people.
+    if ($template_file == 'views/page-stories.blade.php') {
+        remove_post_type_support('page', 'editor');
+    }
+});
+
+add_action('edit_form_after_title', function () {
+    if (isset($_GET['post'])) {
+        $post_id = $_GET['post'];
+    } elseif (isset($_POST['post_ID'])) {
+        $post_id = $_POST['post_ID'];
+    } else {
+        return;
+    }
+    $template_file = get_post_meta($post_id, '_wp_page_template', true);
+    // TODO: Photo credits, people.
+    if ($template_file == 'views/page-stories.blade.php') {
+        echo sprintf(
+            '<div class="notice notice-warning inline"><p>%s</p></div>',
+            __('You are currently editing the page that displays Community Stories.', 'pcc')
+        );
+    }
+});

--- a/resources/views/page-stories.blade.php
+++ b/resources/views/page-stories.blade.php
@@ -1,3 +1,7 @@
+{{--
+  Template Name: Community Stories
+--}}
+
 @extends('layouts.app')
 @section('content')
 @include('partials.page-header-stories')


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

People, Photo Credits and Stories pages don't have any content. This PR hides the editor for these pages.

## Steps to test

1. Edit one of the above pages.

**Expected behavior:** There's no editor, and a helpful message is displayed.

## Additional information

Not applicable.

## Related issues

Not applicable.
