### PR TITLE
Add new "role" on People Page

### DIFF
--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -215,6 +215,11 @@ class Page extends Controller
         return Page::peopleQuery('student-fellow');
     }
 
+    public function researchAffiliateInstituteQuery()
+    {
+        return Page::peopleQuery('research-affilliate-institute');
+    }
+
     public static function peopleQuery($role = false)
     {
         if ($role) {

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -21,6 +21,10 @@
           'query' => $research_fellows_query,
         ],
         [
+          'title' => __('Affiliate Researchers', 'pcc'),
+          'query' => $research_affiliate_institute_query,
+        ],
+        [
           'title' => __('Affiliate Faculty', 'pcc'),
           'query' => $affiliate_faculty_query,
         ],


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This isn't a duplicate of an existing pull request

## Description

<!-- Description of the pull request -->

## Steps to test

1. Go to the page: https://platform.coop/who-we-are/people/
2. Make sure the "Affiliate Researchers" role is displayed before the "Affiliate Faculty"

**Expected behavior:**
The "Affiliate Researchers" role should be available on the "https://platform.coop/who-we-are/people/" page

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here. -->