### PR TITLE
Changed the order of roles

### DIFF
--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -215,6 +215,11 @@ class Page extends Controller
         return Page::peopleQuery('student-fellow');
     }
 
+    public function researchAffiliateInstituteQuery()
+    {
+        return Page::peopleQuery('research-affilliate-institute');
+    }
+
     public static function peopleQuery($role = false)
     {
         if ($role) {

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -21,6 +21,10 @@
           'query' => $research_fellows_query,
         ],
         [
+          'title' => __('Affiliate Researchers', 'pcc'),
+          'query' => $research_affiliate_institute_query,
+        ],
+        [
           'title' => __('Affiliate Faculty', 'pcc'),
           'query' => $affiliate_faculty_query,
         ],

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -9,14 +9,6 @@
     <div id="content">
       @foreach([
         [
-          'title' => __('Staff', 'pcc'),
-          'query' => $staff_query,
-        ],
-        [
-          'title' => __('Council of Advisors', 'pcc'),
-          'query' => $council_query,
-        ],
-        [
           'title' => __('Research Fellows', 'pcc'),
           'query' => $research_fellows_query,
         ],
@@ -27,6 +19,14 @@
         [
           'title' => __('Affiliate Faculty', 'pcc'),
           'query' => $affiliate_faculty_query,
+        ],
+        [
+          'title' => __('Staff', 'pcc'),
+          'query' => $staff_query,
+        ],
+        [
+          'title' => __('Council of Advisors', 'pcc'),
+          'query' => $council_query,
         ],
         [
           'title' => __('Student Fellows', 'pcc'),


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This isn't a duplicate of an existing pull request

## Description

Change the order of "roles" to:
1st Research Fellows
2nd Affiliate Researchers
3rd Affiliate Faculty
4th Staff
5th Council of Advisors

## Steps to test

1. Check the order of the "roles" displayed on the page: https://platform.coopersystem.com.br/who-we-are/people/

**Expected behavior:** The "roles" must be arranged in a new order

## Additional information

## Related issues