### PR TITLE
Added new template page "Events"

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -63,7 +63,7 @@ class App extends Controller
 
     public function donateLink()
     {
-        return (function_exists('\PlatformCoop\Utils\get_config_option'))
+        return (function_exists('\PCCFramework\Utils\get_config_option'))
             ? get_config_option(
                 'donate_link',
                 'https://go.newschool.edu/s/1811/17/interior.aspx?sid=1811&gid=2&pgid=537&cid=1698&dids=34&bledit=1'

--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -219,6 +219,11 @@ class Page extends Controller
     {
         return Page::peopleQuery('research-affilliate-institute');
     }
+    
+    public function affiliatedAdvisorsInstituteQuery()
+    {
+        return Page::peopleQuery('affiliated-advisors-institute');
+    }
 
     public static function peopleQuery($role = false)
     {

--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -215,6 +215,11 @@ class Page extends Controller
         return Page::peopleQuery('student-fellow');
     }
 
+    public function researchAffiliateInstituteQuery()
+    {
+        return Page::peopleQuery('research-affilliate-institute');
+    }
+
     public static function peopleQuery($role = false)
     {
         if ($role) {

--- a/app/Controllers/Projects.php
+++ b/app/Controllers/Projects.php
@@ -26,7 +26,7 @@ class Projects extends Controller
                   'title' => $p->post_title,
                   'image' => get_post_thumbnail_id($p->ID),
                   'slug' => get_post_field('post_name', $p->ID),
-                  'page_link_id' => get_page_link($p->ID)
+                  'page_link_id' => (!empty(get_page_by_path($p->post_name))) ? get_page_link($p->ID) : '#',
                 ];
                 $output[$p->ID]['content'] = (strlen($p->post_content) > 200) ?
                     substr($p->post_content, 0, 200).'...' :

--- a/app/Controllers/Projects.php
+++ b/app/Controllers/Projects.php
@@ -7,7 +7,7 @@ use Sober\Controller\Controller;
 class Projects extends Controller
 {
 
-    public function projects()
+    public static function projects()
     {
         $output = [];
 

--- a/app/Controllers/Projects.php
+++ b/app/Controllers/Projects.php
@@ -26,9 +26,12 @@ class Projects extends Controller
                   'title' => $p->post_title,
                   'image' => get_post_thumbnail_id($p->ID),
                   'slug' => get_post_field('post_name', $p->ID),
-                  'content' => $p->post_content,
                   'page_link_id' => get_page_link($p->ID)
                 ];
+                $output[$p->ID]['content'] = (strlen($p->post_content) > 200) ?
+                    substr($p->post_content, 0, 200).'...' :
+                    $p->post_content;
+                    
                 $page_id = null;
             }
         }

--- a/app/Controllers/Projects.php
+++ b/app/Controllers/Projects.php
@@ -27,7 +27,7 @@ class Projects extends Controller
                   'image' => get_post_thumbnail_id($p->ID),
                   'slug' => get_post_field('post_name', $p->ID),
                   'content' => $p->post_content,
-                  'page_link_id' => get_page_link($page_id)
+                  'page_link_id' => get_page_link($p->ID)
                 ];
                 $page_id = null;
             }

--- a/app/Controllers/SinglePccProject.php
+++ b/app/Controllers/SinglePccProject.php
@@ -85,7 +85,7 @@ class SinglePccProject extends Controller
                     'name' => $name,
                     'short_title' => get_post_meta($researcher_id, 'pcc_person_short_title', true),
                     'slug' => get_post($researcher_id)->post_name,
-                    'page_link' => get_page_link($researcher_id),
+                    'page_link' => (get_page_by_path('teste-de-pessoa')) ? get_page_link($researcher_id) : '#',
                 ];
             }
         }

--- a/app/Controllers/SinglePccProject.php
+++ b/app/Controllers/SinglePccProject.php
@@ -85,11 +85,10 @@ class SinglePccProject extends Controller
                     'name' => $researcher->post_title,
                     'short_title' => get_post_meta($researcher_id, 'pcc_person_short_title', true),
                     'slug' => $researcher->post_name,
-                    'page_link' => (get_page_by_path('teste-de-pessoa')) ? get_page_link($researcher_id) : '#',
+                    'page_link' => (!empty(get_page_by_path($researcher->post_name))) ? get_page_link($researcher->ID) : '#',
                 ];
             }
         }
-
         return $output;
     }
 }

--- a/app/Controllers/SinglePccProject.php
+++ b/app/Controllers/SinglePccProject.php
@@ -85,7 +85,7 @@ class SinglePccProject extends Controller
                     'name' => $researcher->post_title,
                     'short_title' => get_post_meta($researcher_id, 'pcc_person_short_title', true),
                     'slug' => $researcher->post_name,
-                    'page_link' => "people/$researcher->post_name",
+                    'page_link' => get_home_url(null, "people/$researcher->post_name"),
                 ];
             }
         }

--- a/app/Controllers/SinglePccProject.php
+++ b/app/Controllers/SinglePccProject.php
@@ -85,7 +85,7 @@ class SinglePccProject extends Controller
                     'name' => $researcher->post_title,
                     'short_title' => get_post_meta($researcher_id, 'pcc_person_short_title', true),
                     'slug' => $researcher->post_name,
-                    'page_link' => (!empty(get_page_by_path($researcher->post_name))) ? get_page_link($researcher->ID) : '#',
+                    'page_link' => "people/$researcher->post_name",
                 ];
             }
         }

--- a/app/Controllers/SinglePccProject.php
+++ b/app/Controllers/SinglePccProject.php
@@ -80,11 +80,11 @@ class SinglePccProject extends Controller
 
         if ($researchers) {
             foreach ($researchers as $researcher_id) {
-                $name = get_the_title($researcher_id);
-                $output[ $name ] = [
-                    'name' => $name,
+                $researcher = get_post($researcher_id);
+                $output[ $researcher->post_title ] = [
+                    'name' => $researcher->post_title,
                     'short_title' => get_post_meta($researcher_id, 'pcc_person_short_title', true),
-                    'slug' => get_post($researcher_id)->post_name,
+                    'slug' => $researcher->post_name,
                     'page_link' => (get_page_by_path('teste-de-pessoa')) ? get_page_link($researcher_id) : '#',
                 ];
             }

--- a/app/Controllers/SinglePccProject.php
+++ b/app/Controllers/SinglePccProject.php
@@ -84,7 +84,8 @@ class SinglePccProject extends Controller
                 $output[ $name ] = [
                     'name' => $name,
                     'short_title' => get_post_meta($researcher_id, 'pcc_person_short_title', true),
-                    'slug' => get_post($researcher_id)->post_name
+                    'slug' => get_post($researcher_id)->post_name,
+                    'page_link' => get_page_link($researcher_id),
                 ];
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "log1x/blade-svg-sage": "^2.0",
     "log1x/sage-directives": "^1.0",
     "roots/sage-lib": "~9.0.9",
-    "soberwp/controller": "~2.1.0"
+    "soberwp/controller": "~2.1.0",
+    "htmlburger/carbon-fields": "^3.3"
   },
   "require-dev": {
     "roots/sage-installer": "~1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a706977446ce39ca42b87ceade82358",
+    "content-hash": "dd6b088f81b655d84eb169054fbcf610",
     "packages": [
         {
             "name": "brain/hierarchy",
@@ -255,6 +255,145 @@
                 "string"
             ],
             "time": "2018-01-09T20:05:19+00:00"
+        },
+        {
+            "name": "htmlburger/carbon-fields",
+            "version": "v3.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/htmlburger/carbon-fields.git",
+                "reference": "2ae6773c004b873a1b0456613b14852c1a436a96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/htmlburger/carbon-fields/zipball/2ae6773c004b873a1b0456613b14852c1a436a96",
+                "reference": "2ae6773c004b873a1b0456613b14852c1a436a96",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.7",
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon_Fields\\": "core/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "htmlBurger",
+                    "email": "wordpress@htmlburger.com",
+                    "homepage": "https://htmlburger.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Miroslav Mitev",
+                    "email": "mmitev.2create@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Atanas Angelov",
+                    "email": "atanas.angelov.dev@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Georgi Stoyanov",
+                    "email": "stoyanov.gs@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Plamen Kostadinov",
+                    "email": "pkostadinov.2create@gmail.com",
+                    "homepage": "http://plasmen.info/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Stanimir Panchev",
+                    "email": "Stan4omir@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Marin Atanasov",
+                    "email": "contact@marinatanasov.com",
+                    "homepage": "http://marinatanasov.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Siyan Panayotov",
+                    "homepage": "http://siyanpanayotov.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Peter Petrov",
+                    "email": "peter.petrov89@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Stanimir Stoyanov",
+                    "email": "stanimir.k.stoyanov@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Kaloyan Ivanov",
+                    "email": "kaloyanxivanov@gmail.com",
+                    "homepage": "http://vilepixels.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Georgi Popov",
+                    "homepage": "http://magadanski.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "German Velchev",
+                    "email": "germozy@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Rashko Petrov",
+                    "email": "brutalenemy666@gmail.com",
+                    "homepage": "http://errorfactory.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alexander Panayotov",
+                    "email": "alexander.panayotov@gmail.com",
+                    "homepage": "http://alexanderpanayotov.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Viktor Vasilev",
+                    "email": "liberalcho@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Georgi Georgiev",
+                    "email": "george.georgiev96@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Atanas Vasilev",
+                    "email": "atanasvasilev91@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "WordPress developer-friendly custom fields for post types, taxonomy terms, users, comments, widgets, options and more.",
+            "homepage": "http://carbonfields.net/",
+            "support": {
+                "docs": "http://carbonfields.net/docs/",
+                "email": "wordpress@htmlburger.com",
+                "issues": "https://github.com/htmlburger/carbon-fields/issues",
+                "source": "https://github.com/htmlburger/carbon-fields"
+            },
+            "time": "2022-05-05T14:49:59+00:00"
         },
         {
             "name": "illuminate/config",
@@ -1832,5 +1971,6 @@
     "platform": {
         "php": ">=7.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/custom-fields/fields/pages.php
+++ b/custom-fields/fields/pages.php
@@ -12,7 +12,7 @@ function pages() {
 
     $args = [
         'hide_empty' => 1,
-        'exclude' => array_merge([1], $uncat_categories),
+        'exclude' => $uncat_categories,
     ];
     $categories = array_column(get_categories($args), 'name', 'term_id');
 

--- a/custom-fields/fields/pages.php
+++ b/custom-fields/fields/pages.php
@@ -1,0 +1,26 @@
+<?php
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
+function pages() {
+    $uncat_categories = get_terms([
+        'taxonomy' => 'category',
+        'name' => 'Uncategorized',
+        'hide_empty' => true,
+    ]);
+    $uncat_categories = array_column($uncat_categories, 'term_id');
+
+    $args = [
+        'hide_empty' => 1,
+        'exclude' => array_merge([1], $uncat_categories),
+    ];
+    $categories = array_column(get_categories($args), 'name', 'term_id');
+
+    Container::make('post_meta', __('Custom fields'))
+        ->where('post_type', '=', 'page')
+        ->where('post_template', '=', 'views/page-custom-blog.blade.php')
+        ->add_fields([
+            Field::make('select', 'category', __('Select a category'))
+                ->set_options($categories)
+        ]);
+}

--- a/custom-fields/init.php
+++ b/custom-fields/init.php
@@ -16,6 +16,11 @@ class CustomFields
         \Carbon_Fields\Carbon_Fields::boot();
     }
 
+    public function load_fields() {
+        include 'fields/pages.php';
+
+        pages();
+    }
 }
 
 new CustomFields();

--- a/custom-fields/init.php
+++ b/custom-fields/init.php
@@ -1,0 +1,21 @@
+<?php
+
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
+class CustomFields
+{
+    public function __construct() {
+        add_action('after_setup_theme', array($this, 'load_carbon_fields'));
+        add_action('carbon_fields_loaded', array($this, 'load_fields'));
+    }
+
+
+    public function load_carbon_fields() {
+        require_once get_template_directory() . '/../vendor/autoload.php';
+        \Carbon_Fields\Carbon_Fields::boot();
+    }
+
+}
+
+new CustomFields();

--- a/resources/assets/js/filter_events.js
+++ b/resources/assets/js/filter_events.js
@@ -1,0 +1,131 @@
+(function ($) {
+  // Verification to jQuery works only in event template
+  if ($('#pcc-event-template-unique-id').length == 0) {
+    return;
+  }
+  // Take values from url
+  let windowLocation = window.location;
+  let url = new URL(windowLocation.href);
+  let initialCategory = url.searchParams.get("cat") ?? 'all';
+  let initialPage = url.searchParams.get("pg") ?? 1;
+
+  // Apply url params and call ajax
+  window.history.pushState(window.location.href, null, `?cat=${initialCategory}&pg=${initialPage}`);
+  filterEvents(initialCategory, initialPage);
+
+  // Add tab active class
+  $(`[data-value="${initialCategory}"]`).addClass("active");
+
+  // Push the data to url and call ajax to apply new filter and handle with tab active
+  $(".events-category li").click(function () {
+    $(".events-category li").removeClass("active");
+    $(this).addClass("active");
+    let category = $(this).data("value");
+    window.history.pushState(window.location.href, null, `?cat=${category}&pg=1`);
+    filterEvents(category, 1);
+  });
+  
+  // Handle with pagination
+  function navigationPage() {
+    let newUrl = new URL(windowLocation.href);
+    
+    // Add params to next button
+    $('.navigation .next').click(function (event) {
+      event.preventDefault();
+      filterEvents(newUrl.searchParams.get("cat"), parseInt(newUrl.searchParams.get("pg"), 10) + 1)
+      window.history.pushState(window.location.href, null, `?cat=${newUrl.searchParams.get("cat")}&pg=${parseInt(newUrl.searchParams.get("pg"), 10) + 1}`);
+      $("html, body").animate({ scrollTop: 200 }, "smooth");
+    });
+
+    // Add params to previous button
+    $('.navigation .prev').click(function (event) {
+      event.preventDefault();
+      filterEvents(newUrl.searchParams.get("cat"), parseInt(newUrl.searchParams.get("pg"), 10) - 1)
+      window.history.pushState(window.location.href, null, `?cat=${newUrl.searchParams.get("cat")}&pg=${parseInt(newUrl.searchParams.get("pg"), 10) - 1}`);
+      $("html, body").animate({ scrollTop: 200 }, "smooth");
+    });
+
+    // Add pagination ajax call
+    $('.navigation .page-numbers:not(.dots, .next, .prev)').click(function (event) {
+      event.preventDefault();
+      let pageValue = $(this).text();
+      let params = newUrl.searchParams.get("cat") ?? 'all';
+      window.history.pushState(window.location.href, null, `?cat=${params}&pg=${pageValue}`);
+      filterEvents(params, pageValue)
+      $("html, body").animate({ scrollTop: 200 }, "smooth");
+    }) 
+  }
+
+  // Ajax function to filter events
+  function filterEvents(category, currentPage) {
+    $.ajax({
+      url: filter_events_script_ajax.ajax_url,
+      type: "POST",
+      data: {
+        category: category,
+        currentPage: parseInt(currentPage, 10) ?? 1,
+        action: "filter_events",
+        nonce: filter_events_script_ajax.nonce,
+      },
+      beforeSend: function () {
+        $(".events-container").html("Loading...");
+      },
+      success: function (response) {
+        let posts = response.data.posts;
+        let pagination = response.data.pagination;
+        console.log(response.data.posts)
+        if (!posts.length) {
+          $(".events-container").html("No results");
+        } else {
+          $(".events-container").html("");
+        }
+        posts.forEach((post) => {
+          $(".events-container")
+            .append(`
+              <article class="blog card post-2286 pcc-event type-pcc-event status-publish hentry content" style="cursor: pointer;">
+                <figure class="blog__image">
+                ${!post.img ? `
+                  <div class="placeholder-wrap placeholder-wrap-event">
+                      <svg class="placeholder" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.76 78.76">
+                        <defs>
+                        <style>
+                          .stroke{fill:none;stroke:currentColor;stroke-miterlimit:10;stroke-width:2px}.fill{fill:currentColor;}
+                        </style>
+                        </defs>
+                        <path class="stroke" d="M39.38 55.13l-18-51.75-18 51.75h12.37v20.25H27V55.13z"></path>
+                        <path class="stroke" d="M75.38 55.13l-18-51.75-18 51.75h12.37v20.25H63V55.13z"></path>
+                        <circle class="fill" cx="21.38" cy="3.38" r="3.38"></circle><circle class="fill" cx="57.38" cy="3.38" r="3.38"></circle>
+                        <circle class="fill" cx="39.38" cy="55.13" r="3.38"></circle><circle class="fill" cx="51.75" cy="55.13" r="3.38"></circle>
+                        <circle class="fill" cx="63" cy="55.13" r="3.38"></circle><circle class="fill" cx="3.38" cy="55.13" r="3.38"></circle>
+                        <circle class="fill" cx="15.75" cy="55.13" r="3.38"></circle><circle class="fill" cx="27" cy="55.13" r="3.38"></circle>
+                        <circle class="fill" cx="51.75" cy="75.38" r="3.38"></circle><circle class="fill" cx="63" cy="75.38" r="3.38"></circle>
+                        <circle class="fill" cx="15.75" cy="75.38" r="3.38"></circle><circle class="fill" cx="27" cy="75.38" r="3.38"></circle>
+                        <circle class="fill" cx="75.38" cy="55.13" r="3.38"></circle>
+                      </svg>      
+                  </div>`
+                : 
+                `<img src="${post.img}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="">`
+                }
+                </figure>
+                <div class="blog__details">
+                  <header class="text">
+                    <h2 class="title"><a href="${post.link ?? "#"}">${ post.post_title ?? "No title"}</a></h2>
+                  </header>
+                  <time class="updated" datetime="2020-03-13T13:38:04+00:00">${post.start ?? ''}</time>
+                </div>
+              </article>`);
+        });
+
+        if (!pagination) {
+          $(".pagination").html("");
+        } else {
+          $(".pagination").html(pagination);
+          navigationPage();
+        }
+      },
+      error: function (error) {
+        console.log(error);
+      },
+    });
+  }
+})(jQuery);

--- a/resources/assets/styles/_random.css
+++ b/resources/assets/styles/_random.css
@@ -3,7 +3,6 @@
   background: var(--blue);
   background: linear-gradient(90deg, var(--blue) 0%, var(--dark-blue) 100%);
   padding: calc(75 / var(--multiplier) * var(--base)) var(--gutter) var(--spacing-80);
-  margin-bottom: calc(140 / var(--multiplier) * var(--base) * -1);
 }
 
 .wp-block-group.donate h2 {

--- a/resources/assets/styles/components/_cards.css
+++ b/resources/assets/styles/components/_cards.css
@@ -59,6 +59,11 @@
   padding-top: calc(250 / 367 * 100%);
   position: relative;
 }
+.card .placeholder-wrap-event {
+  height: 0;
+  padding-top: calc(165 / 367 * 100%);
+  position: relative;
+}
 
 .blog .card .placeholder-wrap {
   height: 0;

--- a/resources/assets/styles/layouts/_events.css
+++ b/resources/assets/styles/layouts/_events.css
@@ -1,3 +1,44 @@
+.container .events-category {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+  font-family: var(--font-family-sans);
+  overflow-x: auto;
+  white-space: nowrap;
+  padding-bottom: 10px;
+}
+
+.container .events-category li {
+  margin: 0 24px 0 0;
+  cursor: pointer;
+  color: var(--dark-blue);
+}
+
+.container .events-category li:hover {
+  margin: 0 24px 0 0;
+  cursor: pointer;
+  color: var(--blue);
+}
+
+.container .events-category li.active {
+  color: var(--blue);
+  border-bottom: 1px solid var(--blue);
+}
+
+.container .events-category::-webkit-scrollbar {
+  width: 0.3em;
+  height: 0.3em;
+}
+ 
+.container .events-category::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+}
+ 
+.container .events-category::-webkit-scrollbar-thumb {
+  background-color: var(--dark-blue);
+}
+
 .single-pcc-event .banner {
   box-shadow: none;
 }

--- a/resources/assets/styles/layouts/_header.css
+++ b/resources/assets/styles/layouts/_header.css
@@ -315,7 +315,7 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     font-size: 1rem;
     font-weight: normal;
     min-height: 0;
-    padding: 17px 1rem;
+    padding: 17px .7rem;
   }
 
   body:not(.project) .banner .nav .menu-item--languages button {
@@ -334,9 +334,9 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     content: "";
     height: var(--border-medium);
     left: 0;
-    margin-left: 1rem;
+    margin-left: .7rem;
     position: absolute;
-    width: calc(100% - 2rem);
+    width: calc(100% - 1.4rem);
   }
 
   body:not(.project) .banner .nav a:hover,

--- a/resources/assets/styles/layouts/_header.css
+++ b/resources/assets/styles/layouts/_header.css
@@ -457,7 +457,7 @@ body .banner .nav .menu-item--languages button svg {
   }
 
   body .banner .nav > li + li {
-    margin-left: 18px;
+    margin-left: 5px;
   }
 
   body .no-js .banner .nav {

--- a/resources/assets/styles/layouts/_header.css
+++ b/resources/assets/styles/layouts/_header.css
@@ -243,7 +243,7 @@
   width: 2em;
 }
 
-body:not(.project) .banner .nav .menu-item--languages button svg {
+body .banner .nav .menu-item--languages button svg {
   display: none;
 }
 
@@ -271,11 +271,11 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     margin-top: 2.4rem;
   }
 
-  body:not(.project) .menu-toggle {
+  body .menu-toggle {
     display: none;
   }
 
-  body:not(.project) .menu-toggle[aria-expanded="true"] + .banner .nav {
+  body .menu-toggle[aria-expanded="true"] + .banner .nav {
     display: flex;
     float: right;
     position: relative;
@@ -295,7 +295,7 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     word-wrap: normal;
   }
 
-  body:not(.project) .banner .nav {
+  body .banner .nav {
     align-items: flex-end;
     background-color: transparent;
     display: flex;
@@ -308,8 +308,8 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     width: auto;
   }
 
-  body:not(.project) .banner .nav a,
-  body:not(.project) .banner .nav button {
+  body .banner .nav a,
+  body .banner .nav button {
     background: var(--white);
     color: var(--dark-blue);
     font-size: 1rem;
@@ -318,17 +318,17 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     padding: 17px 1rem;
   }
 
-  body:not(.project) .banner .nav .menu-item--languages button {
+  body .banner .nav .menu-item--languages button {
     padding-top: 0.5em;
     padding-bottom: 0.5em;
   }
 
-  body:not(.project) .banner .nav .menu-item--languages button svg {
+  body .banner .nav .menu-item--languages button svg {
     display: inline;
   }
 
-  body:not(.project) .banner .nav a::after,
-  body:not(.project) .banner .nav button::after {
+  body .banner .nav a::after,
+  body .banner .nav button::after {
     background-color: transparent;
     bottom: 0;
     content: "";
@@ -339,134 +339,134 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     width: calc(100% - 2rem);
   }
 
-  body:not(.project) .banner .nav a:hover,
-  body:not(.project) .banner .nav button:hover {
+  body .banner .nav a:hover,
+  body .banner .nav button:hover {
     background-color: white;
     color: var(--dark-blue);
     border-left-color: transparent;
   }
 
-  body:not(.project) .banner .nav a:hover::after,
-  body:not(.project) .banner .nav button:hover::after {
+  body .banner .nav a:hover::after,
+  body .banner .nav button:hover::after {
     background-color: var(--dark-blue);
   }
 
-  body:not(.project) .banner .nav a:focus,
-  body:not(.project) .banner .nav button:focus {
+  body .banner .nav a:focus,
+  body .banner .nav button:focus {
     background-color: var(--dark-blue);
     color: var(--off-white);
     border-left-color: transparent;
     outline: 0;
   }
 
-  body:not(.project) .banner .nav button .icon {
+  body .banner .nav button .icon {
     background-color: var(--dark-blue);
     margin-left: 8px;
     margin-top: 6px;
   }
 
-  body:not(.project) .banner .nav button:focus .icon {
+  body .banner .nav button:focus .icon {
     background-color: var(--off-white);
   }
 
-  body:not(.project) .banner .nav .current-menu-parent button .icon {
+  body .banner .nav .current-menu-parent button .icon {
     background-color: var(--dark-mint);
   }
 
-  body:not(.project) .banner .nav .current-menu-parent button:hover .icon {
+  body .banner .nav .current-menu-parent button:hover .icon {
     background-color: var(--dark-blue);
   }
 
-  body:not(.project) .banner .nav .current-menu-parent button:focus {
+  body .banner .nav .current-menu-parent button:focus {
     color: white;
     background-color: var(--dark-blue);
   }
 
-  body:not(.project) .banner .nav .current-menu-parent button:focus .icon {
+  body .banner .nav .current-menu-parent button:focus .icon {
     background-color: var(--white);
   }
 
-  body:not(.project) .banner .nav [aria-current],
-  body:not(.project) .banner .nav .current-menu-parent button {
+  body .banner .nav [aria-current],
+  body .banner .nav .current-menu-parent button {
     color: var(--dark-mint);
     background-color: var(--white);
     border-left-color: transparent;
   }
 
-  body:not(.project) .banner .nav [aria-current]::after,
-  body:not(.project) .banner .nav .current-menu-parent button::after {
+  body .banner .nav [aria-current]::after,
+  body .banner .nav .current-menu-parent button::after {
     background-color: var(--red);
   }
 
-  body:not(.project) .banner .nav [aria-current]:hover,
-  body:not(.project) .banner .nav .current-menu-parent button:hover {
+  body .banner .nav [aria-current]:hover,
+  body .banner .nav .current-menu-parent button:hover {
     background-color: var(--white);
     border-left-color: transparent;
   }
 
-  body:not(.project) .banner .nav [aria-current]:hover::after,
-  body:not(.project) .banner .nav .current-menu-parent button:hover::after {
+  body .banner .nav [aria-current]:hover::after,
+  body .banner .nav .current-menu-parent button:hover::after {
     background-color: var(--dark-blue);
   }
 
-  body:not(.project) .banner .nav [aria-current]:focus,
-  body:not(.project) .banner .nav .current-menu-parent button:focus {
+  body .banner .nav [aria-current]:focus,
+  body .banner .nav .current-menu-parent button:focus {
     border-left-color: transparent;
   }
 
-  body:not(.project) .banner .nav [aria-current]:focus::after,
-  body:not(.project) .banner .nav .current-menu-parent button:focus::after {
+  body .banner .nav [aria-current]:focus::after,
+  body .banner .nav .current-menu-parent button:focus::after {
     background-color: var(--dark-blue);
   }
 
-  body:not(.project) .banner .nav [aria-current]:focus {
+  body .banner .nav [aria-current]:focus {
     color: white;
     background: var(--dark-blue);
   }
 
-  body:not(.project) .banner .nav ul {
+  body .banner .nav ul {
     border: 1px solid var(--light-grey);
     border-radius: var(--border-radius);
     box-shadow: 0 var(--border-medium) var(--border-wide) rgba(0, 0, 0, 0.16);
     position: absolute;
   }
 
-  body:not(.project) .banner .nav ul a:hover,
-  body:not(.project) .banner .nav ul [aria-current]:hover,
-  body:not(.project) .banner .nav ul a:focus,
-  body:not(.project) .banner .nav ul [aria-current]:focus {
+  body .banner .nav ul a:hover,
+  body .banner .nav ul [aria-current]:hover,
+  body .banner .nav ul a:focus,
+  body .banner .nav ul [aria-current]:focus {
     color: white;
     background: var(--blue);
     border-left-color: transparent;
   }
 
-  body:not(.project) .banner .nav ul a {
+  body .banner .nav ul a {
     padding: 1rem 14px;
   }
 
-  body:not(.project) .banner .nav ul a::after {
+  body .banner .nav ul a::after {
     display: none;
   }
 
-  body:not(.project) .banner .nav ul [aria-current] {
+  body .banner .nav ul [aria-current] {
     border-left-color: var(--red);
   }
 
-  body:not(.project) .banner .nav li {
+  body .banner .nav li {
     border-top: 0;
   }
 
-  body:not(.project) .banner .nav > li + li {
+  body .banner .nav > li + li {
     margin-left: 18px;
   }
 
-  body:not(.project) .no-js .banner .nav {
+  body .no-js .banner .nav {
     display: flex;
     float: right;
     position: relative;
   }
 
-  body:not(.project) .no-js .banner .nav ul {
+  body .no-js .banner .nav ul {
     display: none;
   }
 }

--- a/resources/assets/styles/layouts/_posts.css
+++ b/resources/assets/styles/layouts/_posts.css
@@ -28,9 +28,14 @@
   border-top-color: var(--yellow);
 }
 
+.pcc-event {
+  border-top: solid var(--border-medium) var(--light-red);
+}
+
 .archive .card:hover,
 .blog .card:hover,
-.pcc-story .card:hover {
+.pcc-story .card:hover,
+.pcc-event {
   border-top: solid var(--border-medium) var(--red);
   box-shadow: 0 0 var(--spacing-5) rgba(0, 0, 0, 0.4);
 }

--- a/resources/assets/styles/layouts/_posts.css
+++ b/resources/assets/styles/layouts/_posts.css
@@ -23,6 +23,7 @@
   border-top: solid var(--border-medium) var(--light-red);
   background: var(--white);
   box-shadow: 0 0 var(--spacing-5) rgba(0, 0, 0, 0.16);
+  height: max-content;
 }
 
 .pcc-story .card {

--- a/resources/assets/styles/layouts/pages/_generic.css
+++ b/resources/assets/styles/layouts/pages/_generic.css
@@ -4,7 +4,6 @@
 
 .page main .content {
   background-color: var(--off-white);
-  padding-bottom: var(--spacing-140);
   padding-top: calc(var(--spacing-102) + var(--spacing-2));
 }
 

--- a/resources/assets/styles/layouts/pages/_generic.css
+++ b/resources/assets/styles/layouts/pages/_generic.css
@@ -2,7 +2,7 @@
   background-color: var(--white);
 }
 
-.page main .content {
+.page main .content:not(.pcc-event) {
   background-color: var(--off-white);
   padding-bottom: var(--spacing-140);
   padding-top: calc(var(--spacing-102) + var(--spacing-2));

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -6,6 +6,7 @@
 
 use Roots\Sage\Config;
 use Roots\Sage\Container;
+use app\Controllers\Events;
 
 /**
  * Helper function for prettying up errors
@@ -41,7 +42,7 @@ if (version_compare('4.7.0', get_bloginfo('version'), '>=')) {
  * Ensure dependencies are loaded
  */
 if (!class_exists('Roots\\Sage\\Container')) {
-    if (!file_exists($composer = __DIR__.'/../vendor/autoload.php')) {
+    if (!file_exists($composer = __DIR__ . '/../vendor/autoload.php')) {
         $sage_error(
             __('You must run <code>composer install</code> from the theme directory.', 'pcc'),
             __('Autoloader not found.', 'pcc')
@@ -88,9 +89,14 @@ array_map(
 Container::getInstance()
     ->bindIf('config', function () {
         return new Config([
-            'assets' => require dirname(__DIR__).'/config/assets.php',
-            'theme' => require dirname(__DIR__).'/config/theme.php',
-            'view' => require dirname(__DIR__).'/config/view.php',
-            'blocks' => require dirname(__DIR__).'/config/blocks.php',
+            'assets' => require dirname(__DIR__) . '/config/assets.php',
+            'theme' => require dirname(__DIR__) . '/config/theme.php',
+            'view' => require dirname(__DIR__) . '/config/view.php',
+            'blocks' => require dirname(__DIR__) . '/config/blocks.php',
         ]);
     }, true);
+
+/**
+ * Include helper function ajax to events page
+ */
+include(get_template_directory() . '/helpers/events-ajax.php');

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -94,3 +94,9 @@ Container::getInstance()
             'blocks' => require dirname(__DIR__).'/config/blocks.php',
         ]);
     }, true);
+
+
+/**
+ * Start the Carbon Fields
+ */
+require get_template_directory() . '/../custom-fields/init.php';

--- a/resources/helpers/events-ajax.php
+++ b/resources/helpers/events-ajax.php
@@ -1,0 +1,59 @@
+<?php
+
+// Localize and register script with data for a JS variable
+wp_enqueue_script('filter_events_script', get_template_directory_uri() . '/assets/js/filter_events.js', ['jquery'], '1.0', true);
+wp_localize_script('filter_events_script', 'filter_events_script_ajax', ['ajax_url' => admin_url('admin-ajax.php'), 'nonce'  => wp_create_nonce('ajax_nonce')]);
+
+// Ajax function
+function filter_events() {
+    $category = $_POST['category'];
+    $currentPage = $_POST['currentPage'];
+
+    $meta_query = '';
+    $offset = ($currentPage - 1) * 6;
+
+    if ($category != 'all') {
+        $meta_query = array(
+            array(
+                'key' => 'pcc_event_type',
+                'value' => $category,
+                'compare' => '='
+            )
+        );
+    }
+
+    global $paged;
+
+    $events = new \WP_Query([
+        'post_type' => 'pcc-event',
+        'posts_per_page' => 6,
+        'offset' => $offset,
+        'post_status' => 'publish',
+        'paged' => $paged,
+        'meta_query' => $meta_query
+    ]);
+
+    foreach ($events->posts as $key => $event) {
+        $events->posts[$key]->link = get_permalink($event->ID);
+        $events->posts[$key]->img = get_the_post_thumbnail_url($event->ID) ?? null;
+        $events->posts[$key]->start =  date('M j, Y', get_post_meta($event->ID, 'pcc_event_start')[0]) ?? null;
+    }
+
+    $args_paginate = [
+        'base' => get_permalink() . '/pcc/events' . '%_%?cat=' . $category,
+        'format' => '/page/%#%',
+        'current' => $currentPage,
+        'total' => $events->max_num_pages,
+        'mid_size' => 1,
+        'prev_text' => __('‹ '),
+        'next_text' => __(' ›'),
+    ];
+    
+    $paginate_links = paginate_links($args_paginate);
+    $events->pagination = $paginate_links ?? null;
+
+    return wp_send_json_success($events);
+}
+
+add_action('wp_ajax_nopriv_filter_events', 'filter_events');
+add_action('wp_ajax_filter_events', 'filter_events');

--- a/resources/views/events.blade.php
+++ b/resources/views/events.blade.php
@@ -1,0 +1,43 @@
+{{--
+  Template Name: Events
+--}}
+
+@php
+
+@endphp
+
+@extends('layouts.app')
+
+@section('content')
+    @include('partials.page-header')
+    <div class="container">
+        <ul class="events-category">
+            <li data-value="all">
+                All
+            </li>
+            <li data-value="community">
+                Community Event
+            </li>
+            <li data-value="conference">
+                PCC Conference
+            </li>
+            <li data-value="pcc">
+                PCC Event
+            </li>
+            <li data-value="icde">
+                ICDE Event
+            </li>
+            <li data-value="course">
+                Course
+            </li>
+        </ul>
+    </div>
+    <div id="pcc-event-template-unique-id" class="content">
+        <div class="wp-block-group">
+            <div class="cards cards--three-columns  events-container">
+            </div>
+            <nav class="navigation pagination" aria-label="Posts">
+            </nav>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,3 +1,14 @@
+@php
+  global $template;
+  $custom_temp = 'page-custom-blog.blade.php';
+  if (basename($template) === $custom_temp) {
+    add_filter('body_class', function ($classes) {
+      $classes = ['blog logged-in admin-bar no-customize-support wp-embed-responsive multi-author-false app-data index-data home-data'];
+      return $classes;
+    });
+  }
+@endphp
+
 <!doctype html>
 <html class="no-js" {!! get_language_attributes() !!}>
   @include('partials.head')

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -1,5 +1,5 @@
 {{--
-  Template Name: Blog
+  Template Name: Blog Category View
 --}}
 
 @php

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -1,0 +1,53 @@
+{{--
+  Template Name: Blog
+--}}
+
+@extends('layouts.app')
+
+@section('content')
+  @include('partials.page-header')
+    <div id="content">
+      <div class="wp-block-group">
+        <div class="cards cards--three-columns">
+        @if (!have_posts())
+          <div class="alert alert-warning">
+            {{ __('Sorry, no results were found.', 'pcc') }}
+          </div>
+          {!! get_search_form(false) !!}
+        @endif
+
+        @php
+            global $paged;
+            $curpage = $paged ? $paged : 1;
+            $args = [
+              'post_type' => 'post',
+              'showposts' => 12,
+              'orderby' => 'date',
+              'order'   => 'DESC',
+              // 'cat' => 3,
+              'paged' => $paged
+            ];
+            $blog_posts = new WP_Query($args);
+        @endphp
+        @while ($blog_posts->have_posts()) @php $blog_posts->the_post() @endphp
+          @include('partials.content-'.get_post_type())
+        @endwhile
+      </div>
+
+      <nav class="navigation pagination" aria-label="Posts">
+        {!!
+          paginate_links([
+            'base' => get_pagenum_link(1) . '%_%',
+            'format' => 'page/%#%',
+            'current' => max( 1, get_query_var( 'paged' ) ),
+            'total' => $blog_posts->max_num_pages,
+            'mid_size'    => 1,
+            'prev_text'    => __('‹ '),
+            'next_text'    => __(' ›'),
+          ]);
+          wp_reset_postdata();
+        !!}
+      </nav>
+    </div>
+  </div>
+@endsection

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -2,6 +2,19 @@
   Template Name: Blog
 --}}
 
+@php
+  $args_paginate = [
+    'base' => get_pagenum_link(1) . '%_%',
+    'format' => 'page/%#%',
+    'current' => max( 1, get_query_var( 'paged' ) ),
+    'total' => $blog_posts->max_num_pages,
+    'mid_size'    => 1,
+    'prev_text'    => __('‹ '),
+    'next_text'    => __(' ›'),
+  ];
+  $paginate_links = paginate_links($args_paginate);
+@endphp
+
 @extends('layouts.app')
 
 @section('content')
@@ -35,18 +48,10 @@
       </div>
 
       <nav class="navigation pagination" aria-label="Posts">
-        {!!
-          paginate_links([
-            'base' => get_pagenum_link(1) . '%_%',
-            'format' => 'page/%#%',
-            'current' => max( 1, get_query_var( 'paged' ) ),
-            'total' => $blog_posts->max_num_pages,
-            'mid_size'    => 1,
-            'prev_text'    => __('‹ '),
-            'next_text'    => __(' ›'),
-          ]);
+        @php
+          echo $paginate_links;
           wp_reset_postdata();
-        !!}
+        @endphp
       </nav>
     </div>
   </div>

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -3,6 +3,20 @@
 --}}
 
 @php
+  global $paged;
+  $curpage = $paged ? $paged : 1;
+  $category = carbon_get_the_post_meta('category') ?? -1;
+
+  $args_posts = [
+    'post_type' => 'post',
+    'showposts' => 12,
+    'orderby' => 'date',
+    'order'   => 'DESC',
+    'cat' => $category,
+    'paged' => $paged
+  ];
+  $blog_posts = new WP_Query($args_posts);
+
   $args_paginate = [
     'base' => get_pagenum_link(1) . '%_%',
     'format' => 'page/%#%',
@@ -28,20 +42,6 @@
           </div>
           {!! get_search_form(false) !!}
         @endif
-
-        @php
-            global $paged;
-            $curpage = $paged ? $paged : 1;
-            $args = [
-              'post_type' => 'post',
-              'showposts' => 12,
-              'orderby' => 'date',
-              'order'   => 'DESC',
-              // 'cat' => 3,
-              'paged' => $paged
-            ];
-            $blog_posts = new WP_Query($args);
-        @endphp
         @while ($blog_posts->have_posts()) @php $blog_posts->the_post() @endphp
           @include('partials.content-'.get_post_type())
         @endwhile

--- a/resources/views/page-icde.blade.php
+++ b/resources/views/page-icde.blade.php
@@ -9,31 +9,4 @@
     @include('partials.page-header')
     @include('partials.content-page')
   @endwhile
-  @if(!empty(Projects::projects()))
-    <div class="projects-container">
-      <div class="wp-block-columns has-2-columns">
-        <div class="wp-block-column">
-          <h2>Projects</h2>
-          <p>The institute orchestrates various research projects around the world.</p>
-        </div>
-        <div class="wp-block-column">
-          <ul class="cards projects cards--two-columns">
-            @foreach(Projects::projects() as $project)
-                <article class="card post format-standard status-publish has-post-thumbnail">
-                  <div class="project__details">
-                    <header class="text">
-                      <h2 class="title">
-                        <a href="{!! $project['page_link_id'] !!}">{!! $project['title'] !!}</a>
-                      </h2>
-                      <p class="desc">{!! $project['content'] !!}</p>
-                    </header>
-                  </div>
-                  <figure>{!! wp_get_attachment_image($project['image'], 'medium') !!}</figure>
-                </article>
-            @endforeach
-          </ul>
-        </div>
-      </div>
-    </div>
-  @endif
 @endsection

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -31,7 +31,11 @@
         [
           'title' => __('Student Fellows', 'pcc'),
           'query' => $student_fellows_query,
-        ]
+        ],
+        [
+          'title' => __('Affiliated Advisors', 'pcc'),
+          'query' => $affiliated_advisors_institute_query,
+        ],
         ] as $query)
         @if ($query['query']->have_posts())
         <div class="wp-block-group">

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -21,6 +21,10 @@
           'query' => $research_fellows_query,
         ],
         [
+          'title' => __('Affiliate Researchers', 'pcc'),
+          'query' => $research_affiliate_institute_query,
+        ],
+        [
           'title' => __('Affiliate Faculty', 'pcc'),
           'query' => $affiliate_faculty_query,
         ],

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -9,14 +9,6 @@
     <div id="content">
       @foreach([
         [
-          'title' => __('Staff', 'pcc'),
-          'query' => $staff_query,
-        ],
-        [
-          'title' => __('Council of Advisors', 'pcc'),
-          'query' => $council_query,
-        ],
-        [
           'title' => __('Research Fellows', 'pcc'),
           'query' => $research_fellows_query,
         ],
@@ -27,6 +19,14 @@
         [
           'title' => __('Affiliate Faculty', 'pcc'),
           'query' => $affiliate_faculty_query,
+        ],
+        [
+          'title' => __('Staff', 'pcc'),
+          'query' => $staff_query,
+        ],
+        [
+          'title' => __('Council of Advisors', 'pcc'),
+          'query' => $council_query,
         ],
         [
           'title' => __('Student Fellows', 'pcc'),

--- a/resources/views/partials/project-breadcrumbs.blade.php
+++ b/resources/views/partials/project-breadcrumbs.blade.php
@@ -1,7 +1,6 @@
 <div class="project-breadcrumbs">
   <p class="breadcrumb">
     <a href="/">{{ __('Home', 'pcc') }}</a>
-    <a href="/who-we-are/icde">{{ __('ICDE', 'pcc') }}</a>
     @if($post->post_parent)
       @foreach (SinglePccProject::ancestors() as $a)
         <a href="{{ $a['url'] }}">{{ $a['name'] }}</a>

--- a/resources/views/single-pcc-project.blade.php
+++ b/resources/views/single-pcc-project.blade.php
@@ -26,7 +26,11 @@
           <div class="col">
             <ul class="section-ul researcher-list">
               @foreach(SinglePccProject::researchers() as $researcher)
-                <li><a href="/people/{{ $researcher['slug'] }}/">{!! $researcher['name'] !!}</a></li>
+                <li>
+                  <a href="{{ $researcher['page_link'] }}">
+                    {!! $researcher['name'] !!}
+                  </a>
+                </li>
               @endforeach
             <ul>
           </div>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Added new events template page with tabs to show events filtered by event type

## Steps to test

1. Create a page and set the new template "Events"
2. Open the new page created
3. You should be able to see the events and navigate in tabs

**Expected behavior:** Show events page and the tabs navigation to filter events

## Additional information

The template page use ajax, then it's no necessary reload the page to change the page and tabs.

